### PR TITLE
chore(libparse): implement helper functions to match route index and …

### DIFF
--- a/libparse/match.cpp
+++ b/libparse/match.cpp
@@ -69,26 +69,18 @@ libparse::matchPathWithLocation(const libparse::Routes &routes, const std::strin
   return std::make_pair(maxMatch, &routes.at(maxMatch));
 }
 
-std::string libparse::findRouteRoot(const libparse::Domain *domain, const std::string &routeName) {
-  std::map<std::string, libparse::RouteProps>::const_iterator routeIter = domain->routes.find(routeName);
-
-  if (routeIter == domain->routes.end())
-    return "";
-
-  if (routeIter->second.root.empty() == false)
-    return routeIter->second.root;
+std::string libparse::findRouteRoot(const libparse::Domain     *domain,
+                                    const libparse::RouteProps *route) {
+  if (route->root.empty() == false)
+    return route->root;
   else
     return domain->root;
 }
 
-std::string libparse::findRouteIndex(const libparse::Domain *domain, const std::string &routeName) {
-  std::map<std::string, libparse::RouteProps>::const_iterator routeIter = domain->routes.find(routeName);
-
-  if (routeIter == domain->routes.end())
-    return "";
-
-  if (routeIter->second.index.empty() == false)
-    return routeIter->second.index;
+std::string libparse::findRouteIndex(const libparse::Domain     *domain,
+                                     const libparse::RouteProps *route) {
+  if (route->index.empty() == false)
+    return route->index;
   else
     return domain->index;
 }

--- a/libparse/match.hpp
+++ b/libparse/match.hpp
@@ -10,6 +10,6 @@ namespace libparse {
   std::pair<std::string, const RouteProps *> matchPathWithLocation(const Routes      &routes,
                                                                    const std::string &path);
 
-  std::string findRouteRoot(const libparse::Domain *domain, const std::string &route);
-  std::string findRouteIndex(const libparse::Domain *domain, const std::string &route);
+  std::string findRouteRoot(const libparse::Domain *domain, const libparse::RouteProps *route);
+  std::string findRouteIndex(const libparse::Domain *domain, const libparse::RouteProps *route);
 } // namespace libparse


### PR DESCRIPTION
## Basic test
```c++
  std::string root = libparse::findRouteRoot(domain, route);
  std::string index = libparse::findRouteIndex(domain, route);

  std::cout << "root: " << root << std::endl;
  std::cout << "index: " << index << std::endl;

```

## Note
its better to used along with other helper 